### PR TITLE
Package improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "scripts": {
     "commit": "git-cz",
-    "test": "mocha src/index.test.js",
+    "test": "mocha src/index.test.js --require esm",
     "check-coverage": "nyc npm run test",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
@@ -20,6 +20,7 @@
     "nokia"
   ],
   "files": [
+    "src/index.js",
     "README.md"
   ],
   "author": "Dinesh Manajipet <saidinesh5@gmail.com> (https://github.com/adamonsoon)",
@@ -33,6 +34,7 @@
     "codecov": "3.8.1",
     "commitizen": "2.9.6",
     "cz-conventional-changelog": "2.0.0",
+    "esm": "^3.2.25",
     "ghooks": "2.0.4",
     "mocha": "3.2.0",
     "nyc": "15.1.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   },
   "config": {
     "ghooks": {
-      "pre-commit": "npm run test && npm run check-coverage"
+      "pre-commit": "npm run check-coverage"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "commit": "git-cz",
     "test": "mocha src/index.test.js --require esm",
-    "check-coverage": "nyc npm run test",
+    "check-coverage": "c8 --reporter=text --reporter=lcov npm run test",
     "report-coverage": "cat ./coverage/lcov.info | codecov",
     "semantic-release": "semantic-release pre && npm publish && semantic-release post"
   },
@@ -30,6 +30,7 @@
   },
   "homepage": "https://github.com/saidinesh5/bluejay-rtttl-parse#readme",
   "devDependencies": {
+    "c8": "^7.6.0",
     "chai": "3.5.0",
     "codecov": "3.8.1",
     "commitizen": "2.9.6",
@@ -37,7 +38,6 @@
     "esm": "^3.2.25",
     "ghooks": "2.0.4",
     "mocha": "3.2.0",
-    "nyc": "15.1.0",
     "semantic-release": "^17.4.2",
     "sinon": "^10.0.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -16,8 +16,6 @@
 // ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-"use strict";
-
 class Rtttl {
 
 /**
@@ -482,4 +480,4 @@ static _calculateFrequencyFromBluejayTemp3(temp3) {
 
 }
 
-typeof module !== 'undefined'? module.exports = Rtttl : null;
+export default Rtttl;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1,8 +1,6 @@
-"use strict";
-
-const expect     = require('chai').expect;
-const sinon      = require('sinon');
-const rtttlParse = require('./index.js');
+import { expect } from 'chai';
+import sinon from 'sinon';
+import rtttlParse from './index.js';
 
 describe('parse', () => {
 


### PR DESCRIPTION
Hey @saidinesh5 I updated the dependencies so you can run mocha on ES6 tests. Also added coverage checking via c8 since nyc does not yet like ES6.

Further I whitelisted `src/index.js` for packaging.

I would highly recommend you add an eslint config to keep the code consistent and "force" other contributors to contribute in the same style.